### PR TITLE
I was wrong

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -864,25 +864,33 @@ final class SiteApplication extends CMSApplication
 	 *
 	 * @param   string  $template     The template name
 	 * @param   mixed   $styleParams  The template style parameters
-	 * @param   int     $inheritable  Support for inheritance
-	 * @param   string  $parent       The name of the parent template
 	 *
 	 * @return  void
 	 *
 	 * @since   3.2
 	 */
-	public function setTemplate($template, $styleParams = null, inheritable = 0, $parent= null)
+	public function setTemplate($template, $styleParams = null)
 	{
 		if (is_dir(JPATH_THEMES . '/' . $template))
 		{
 			$this->template = new \stdClass;
 			$this->template->template = $template;
-			$this->template->inheritable = inheritable;
-			$this->template->parent = $parent;
+			$this->template->inheritable = 0;
+			$this->template->parent = '';
 			
 			if ($styleParams instanceof Registry)
 			{
 				$this->template->params = $styleParams;
+				
+				if (isset($styleParams->inheritable))
+				{
+					$this->template->inheritable = $styleParams->inheritable;
+				}
+
+				if (isset($styleParams->parent))
+				{
+					$this->template->parent = $styleParams->parent;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Both inheritable and parent are params from the template_styles table, so it makes sense to keep them consistent

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

